### PR TITLE
Also run `build_test_push_stopgap_predictmd` as a daily cron job

### DIFF
--- a/.github/workflows/test_stopgap_predictmd.yml
+++ b/.github/workflows/test_stopgap_predictmd.yml
@@ -6,6 +6,9 @@ on:
       - master
       - staging
       - trying
+  schedule:
+    - cron: '00 00 * * *'
+
 jobs:
   build_test_push_stopgap_predictmd:
     runs-on: ${{ matrix.os }}
@@ -26,12 +29,12 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - run: julia --project -e 'using SimpleContainerGenerator; pkgs = [(name = "PredictMD", rev = "master"), (name = "PredictMDExtra", rev = "master"), (name = "PredictMDFull", rev = "master")]; stopgap_docker(pkgs; julia_version = "nightly")'
-      - if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      - if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'schedule')
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - run: docker build -t dilumaluthge/stopgap_predictmd .
       - run: docker run dilumaluthge/stopgap_predictmd "JULIA_DEBUG=all PREDICTMD_TEST_GROUP=all PREDICTMD_TEST_PLOTS=true /usr/bin/stopgap_julia -e 'import Pkg; Pkg.test(string(:PredictMDExtra)); Pkg.test(string(:PredictMDFull)); Pkg.test(string(:PredictMD))'"
-      - if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      - if: success() && github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'schedule')
         run: docker push dilumaluthge/stopgap_predictmd


### PR DESCRIPTION
So `build_test_push_stopgap_predictmd` will run on
1. Pull request
2. Push to master
3. Daily cron job