### PR TITLE
Fix the build, now that NVIDIA has removed the `latest` tag from the `nvidia/cuda` Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,7 @@ on:
       - master
       - staging
       - trying
-  schedule:
-    - cron: '00 00,12 * * *'
+  workflow_dispatch:
 
 jobs:
   CI:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
       - staging
       - trying
   workflow_dispatch:
-
 jobs:
   CI:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/predictmd.yml
+++ b/.github/workflows/predictmd.yml
@@ -28,7 +28,7 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
-      - run: julia --project -e 'import SimpleContainerGenerator; pkgs = [(name = "PredictMD", rev = "master", ), (name = "PredictMDExtra", rev = "master", ), (name = "PredictMDFull", rev = "master", ), (name = "UnicodePlots", version = "1.2.0 - *", ),]; no_test = String["UnicodePlots"]; parent_image = "nvidia/cuda"; tests_must_pass = String["PredictMD", "PredictMDExtra", "PredictMDFull"]; SimpleContainerGenerator.create_dockerfile(pkgs; no_test = no_test, parent_image = parent_image, tests_must_pass = tests_must_pass)'
+      - run: julia --project -e 'import SimpleContainerGenerator; pkgs = [(name = "PredictMD", rev = "master", ), (name = "PredictMDExtra", rev = "master", ), (name = "PredictMDFull", rev = "master", ), (name = "UnicodePlots", version = "1.2.0 - *", ),]; no_test = String["UnicodePlots"]; parent_image = "nvidia/cuda:11.2.0-devel-ubuntu20.04"; tests_must_pass = String["PredictMD", "PredictMDExtra", "PredictMDFull"]; SimpleContainerGenerator.create_dockerfile(pkgs; no_test = no_test, parent_image = parent_image, tests_must_pass = tests_must_pass)'
       - if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'schedule')
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/predictmd.yml
+++ b/.github/workflows/predictmd.yml
@@ -32,14 +32,14 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker --config ~/.dockerconfig1 login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'schedule')
+      - if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker --config ~/.dockerconfig2 login docker.pkg.github.com -u bcbi --password-stdin
       - run: docker build -t dilumaluthge/predictmd -t docker.pkg.github.com/bcbi/simplecontainergenerator.jl/predictmd .
       - run: docker run dilumaluthge/predictmd "JULIA_DEBUG=all PREDICTMD_TEST_GROUP=all PREDICTMD_TEST_PLOTS=true /usr/bin/julia -e 'import Pkg; Pkg.test(string(:PredictMDExtra)); Pkg.test(string(:PredictMDFull)); Pkg.test(string(:PredictMD))'"
-      - if: success() && github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'schedule')
+      - if: success() && github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: docker --config ~/.dockerconfig1 push dilumaluthge/predictmd
-      - if: success() && github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'schedule')
+      - if: success() && github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: docker --config ~/.dockerconfig2 push docker.pkg.github.com/bcbi/simplecontainergenerator.jl/predictmd
         continue-on-error: true

--- a/.github/workflows/predictmd.yml
+++ b/.github/workflows/predictmd.yml
@@ -6,9 +6,7 @@ on:
       - master
       - staging
       - trying
-  schedule:
-    - cron: '00 00,12 * * *'
-
+  workflow_dispatch:
 jobs:
   PredictMD_docker:
     runs-on: ${{ matrix.os }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleContainerGenerator"
 uuid = "b8d349fb-717b-4aac-a9b1-e1da4219c631"
 authors = ["Dilum Aluthge"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ pkgs = [
     "Baz",
 ]
 julia_version = v"1.4.0"
-parent_image = "nvidia/cuda:latest"
+parent_image = "nvidia/cuda:11.2.0-devel-ubuntu20.04"
 
 SimpleContainerGenerator.create_dockerfile(pkgs;
                                            julia_version = julia_version,


### PR DESCRIPTION
> With the next major release of CUDA at the end of the year, we will be deprecating the use of the "latest" tag for all CUDA container images on NGC and Docker Hub.
> 
> After the removal of the latest tag, the following use case will result in the "manifest unknown" error:

Source: https://gitlab.com/nvidia/container-images/cuda/-/blob/8b7f8dee00f238a03ed3439dff768170722f9a6d/README.md

